### PR TITLE
Feat/178(LocalDateTime 원하는 Format으로 바인딩하기)

### DIFF
--- a/backend/src/main/java/woorifisa/goodfriends/backend/admin/dto/response/UserLogRecordResponse.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/admin/dto/response/UserLogRecordResponse.java
@@ -1,5 +1,6 @@
 package woorifisa.goodfriends.backend.admin.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import woorifisa.goodfriends.backend.user.domain.User;
 
@@ -11,6 +12,8 @@ public class UserLogRecordResponse {
     private String email;
     private String nickname;
     private int banCount;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime lastModifiedAt;
 
     protected UserLogRecordResponse() {

--- a/backend/src/main/java/woorifisa/goodfriends/backend/product/dto/response/ProductViewOneResponse.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/product/dto/response/ProductViewOneResponse.java
@@ -1,5 +1,6 @@
 package woorifisa.goodfriends.backend.product.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import woorifisa.goodfriends.backend.product.domain.ProductCategory;
 import woorifisa.goodfriends.backend.product.domain.ProductStatus;
 
@@ -24,8 +25,10 @@ public class ProductViewOneResponse {
 
     private int sellPrice;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime createdDate;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime lastModifiedDate;
 
     private List<String> imageUrls;


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 연관된 이슈 번호를 모두 작성해주세요

- Close #178 

## ✍🏻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

로그 기록을 조회할 때, 상품 상세 페이지 조회할 때 LocalDateTime을 원하는 Format으로 바인딩하기 위해 JsonFormat 어노테이션을 적용했습니다.

- [x] UserLogRecordResponse, ProductViewOneResponse에 `@JsonFormat` 적용

```java
* 기본 전제 : LocalDateTime의 기본 형식인 'yyyy-MM-dd'T'HH:mm:ss'이 아닐 때

1. @RequestBody, @ResponseBody : @JsonFormat 사용
2. @RequestParam, @ModelAttribute : @DateTimeFormat 사용
```

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

