### PR TITLE
Feature/237(N번 신고당한 사용자는 거래를 일시적으로 제한하도록 기능 구현)

### DIFF
--- a/backend/src/main/java/woorifisa/goodfriends/backend/offender/domain/Offender.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/offender/domain/Offender.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @SuperBuilder
-@Table(name = "offenders")
+@Table(name = "offenders") // 부정행위자
 @Entity
 public class Offender extends BaseCreateTimeEntity {
 
@@ -20,7 +20,6 @@ public class Offender extends BaseCreateTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id") // 외래 키로 사용할 컬럼 지정
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     protected Offender() {

--- a/backend/src/main/java/woorifisa/goodfriends/backend/offender/domain/Offender.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/offender/domain/Offender.java
@@ -23,8 +23,6 @@ public class Offender extends BaseCreateTimeEntity {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
-    private LocalDateTime limitedDate;
-
     protected Offender() {
     }
 
@@ -36,7 +34,4 @@ public class Offender extends BaseCreateTimeEntity {
         return user;
     }
 
-    public LocalDateTime getLimitedDate() {
-        return limitedDate;
-    }
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/offender/domain/Offender.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/offender/domain/Offender.java
@@ -28,11 +28,6 @@ public class Offender extends BaseCreateTimeEntity {
     protected Offender() {
     }
 
-    public Offender(User user, LocalDateTime limitedDate) {
-        this.user = user;
-        this.limitedDate = limitedDate;
-    }
-
     public Long getId() {
         return id;
     }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/offender/domain/Offender.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/offender/domain/Offender.java
@@ -1,0 +1,47 @@
+package woorifisa.goodfriends.backend.offender.domain;
+
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import woorifisa.goodfriends.backend.global.common.BaseCreateTimeEntity;
+import woorifisa.goodfriends.backend.user.domain.User;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@SuperBuilder
+@Table(name = "offenders")
+@Entity
+public class Offender extends BaseCreateTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id") // 외래 키로 사용할 컬럼 지정
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    private LocalDateTime limitedDate;
+
+    protected Offender() {
+    }
+
+    public Offender(User user, LocalDateTime limitedDate) {
+        this.user = user;
+        this.limitedDate = limitedDate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public LocalDateTime getLimitedDate() {
+        return limitedDate;
+    }
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/offender/domain/OffenderRepository.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/offender/domain/OffenderRepository.java
@@ -1,0 +1,6 @@
+package woorifisa.goodfriends.backend.offender.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OffenderRepository extends JpaRepository<Offender, Long> {
+}

--- a/backend/src/main/java/woorifisa/goodfriends/backend/product/domain/ProductRepository.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/product/domain/ProductRepository.java
@@ -30,4 +30,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "SET p.status = :productStatus " +
             "WHERE p.id = :productId")
     void updateProductStatus(Long productId, ProductStatus productStatus);
+
+    @Query("SELECT p FROM Product p " +
+            "JOIN FETCH User u " +
+            "ON p.id = :productId " +
+            "AND p.user.id = u.id")
+    Product getByProductIdAndUserId(Long productId);
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/report/application/ReportService.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/report/application/ReportService.java
@@ -3,6 +3,7 @@ package woorifisa.goodfriends.backend.report.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import woorifisa.goodfriends.backend.auth.dto.LoginUser;
+import woorifisa.goodfriends.backend.offender.domain.Offender;
 import woorifisa.goodfriends.backend.report.domain.Report;
 import woorifisa.goodfriends.backend.report.domain.ReportRepository;
 import woorifisa.goodfriends.backend.report.dto.request.ReportSaveRequest;
@@ -32,12 +33,27 @@ public class ReportService {
     @Transactional
     public Long saveReport(LoginUser loginUser, Long productId, ReportSaveRequest request) {
 
+        // 신고 등록하면 신고 테이블 (신고한 유저, 신고 카테고리, 신고 내용) 생성
         User foundUser = userRepository.getById(loginUser.getId());
-        Product foundProduct = productRepository.getById(productId);
+        Product foundProduct = productRepository.getByProductIdAndUserId(productId);
 
         Report newReport = createDeclaration(foundUser, foundProduct, request);
         reportRepository.save(newReport);
 
+        // 신고 당한 유저는 횟수 + 1 증가
+        int updatedBan = foundProduct.getUser().getBan() + 1;
+        foundProduct.getUser().updateBan(updatedBan);
+
+        // 신고 당한 유저의 ban 횟수가 3이면 비활성화 상태로 변경, 부정행위자에 추가
+        if(updatedBan >= 3) {
+            boolean notActivated = false;
+            foundProduct.getUser().updateActivated(notActivated);
+
+            createOffender(foundProduct.getUser());
+        }
+
+        // 신고당한 유저의 신고 당한 횟수 업데이트
+        userRepository.save(foundProduct.getUser());
         return newReport.getId();
     }
     private Report createDeclaration(User user, Product product , ReportSaveRequest request) {
@@ -49,5 +65,12 @@ public class ReportService {
                 .product(product)
                 .build();
         return newReport;
+    }
+
+    private void createOffender(User offenderUser) {
+        Offender.builder()
+                .user(offenderUser)
+                .limitedDate(offenderUser.getLastModifiedAt())
+                .build();
     }
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/report/domain/Report.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/report/domain/Report.java
@@ -22,7 +22,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Embedded;
 
 @SuperBuilder
-@Table(name = "declarations")
+@Table(name = "reports")
 @Entity
 public class Report extends BaseCreateTimeEntity {
 

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/User.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/User.java
@@ -81,5 +81,11 @@ public class User extends BaseTimeEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public void updateBan(int ban) {
+        this.ban = ban;
     }
+    public void updateActivated(boolean activated) {
+        this.activated = activated;
+    }
+
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/User.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/user/domain/User.java
@@ -29,7 +29,7 @@ public class User extends BaseTimeEntity {
 
     private int ban;
 
-    private  boolean activated;
+    private  boolean activated = true;
 
     protected User() {
     }
@@ -45,6 +45,10 @@ public class User extends BaseTimeEntity {
         if (!matcher.matches()) {
             throw new InvalidUserException();
         }
+    }
+
+    public void setActivated(boolean activated) {
+        this.activated = activated;
     }
 
     public Long getId() {
@@ -66,6 +70,9 @@ public class User extends BaseTimeEntity {
     public int getBan() {
         return ban;
     }
+    public boolean isActivated() {
+        return activated;
+    }
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
@@ -74,7 +81,5 @@ public class User extends BaseTimeEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
-    public boolean isActivated() {
-        return activated;
     }
 }

--- a/frontend/src/apis/user/login.ts
+++ b/frontend/src/apis/user/login.ts
@@ -10,7 +10,7 @@ const redirectUri = import.meta.env.VITE_APP_REDIRECT_URI;
 
 const loginAPI = {
   endPoint: {
-    urlLogin: `api/auth/google/oauth-uri?oauthProvier=${oauthProvier}&redirectUri=${redirectUri}/`,
+    urlLogin: `api/auth/google/oauth-uri?oauthProvier=${oauthProvier}&redirectUri=${redirectUri}`,
     getAccessToken: `api/auth/google/token/`,
     logout: `api/auth/logout/`,
     getAccessTokenWithRefresh: 'api/auth/token/access/'


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 연관된 이슈 번호를 모두 작성해주세요

- Close #237 

## ✍🏻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- N번 신고당한 사용자는 거래를 일시적으로 제한하도록 기능을 구현했습니다.
- 사용자가 신고 등록할 때, 해당 상품에 등록한 유저에 대한 신고 횟수(ban) +1 증가
- 신고 횟수가 3번이상이면 해당 유저는 비활성화로 변경 및 부정행위자로 등록

### 신고 시나리오

> 신고에 대한 **유저 시나리오는 이후에 추가 기획을 거쳐 사용자에 맞게 바뀔 것**이기 때문에 `확정`이 아닙니다.
> 신고 시나리오를 이해하기 위해 유저1,2에 대한 가정을 두었습니다.
유저1: 신고를 하는 유저: **팬시**
유저2: 신고를 당한 유저: **브루스**

1. `팬시`가 타인이 등록한 상품에 대해 신고를 한다.
2. 신고를 당한 `브루스`는 ban(신고 횟수)가 +1이 증가된다.
2-1. 만약 신고 횟수가 3이상일 경우 `브루스`는 (활성화에서)비활성화 상태로 바뀐다.
2-2. `브루스`는 신고 횟수 기준(3번)을 넘었기 때문에 `부정행위자`로 간주되며 부정행위자 테이블에 등록된다.
3. 부정행위자에 등록된 `브루스`는 더이상 `굿프렌즈 서비스`를 이용할 수 없게 된다. 
3-1. 다른 페이지로 이동할 시 `부정행위자로 등록되어 더이상 해당 서비스를 이용할 수 없게 되었습니다.`


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

1. 해당 시나리오에 대해 괜찮으신가요? 추가될 것이 있다면 아래에 의견을 작성해 주시면 감사하겠습니다! 😊
2. 신고 시나리오에 대한 플로우는 이후에 관리자의 `신고 관리` 기능이 추가되면 바뀔 것입니다.
