### PR TITLE
Feature/283( 상품 API 수정 및 무한스크롤 구현 )

### DIFF
--- a/frontend/src/apis/user/product.ts
+++ b/frontend/src/apis/user/product.ts
@@ -4,6 +4,7 @@ import type { IAllProduct, IDetailEditProduct, IDetailProduct } from '@/types/pr
 import { type AxiosResponse } from 'axios';
 
 const api = apiInstance();
+const MAX_SIZE = 15;
 
 const productAPI = {
   endPoint: {
@@ -17,10 +18,10 @@ const productAPI = {
     getSerchTitleProduct: `api/products/search/`
   },
   headers: {},
-  getAll: (): Promise<IResultType<Array<IAllProduct>>> => {
+  getAll: (page: number, size = MAX_SIZE): Promise<IResultType<Array<IAllProduct>>> => {
     // 전체 조회
     return api
-      .get(productAPI.endPoint.getAll)
+      .get(productAPI.endPoint.getAll, { params: { page, size } })
       .then((res: AxiosResponse) => {
         const { data } = res;
         return { isSuccess: true, data: data.responses, code: res.status };
@@ -155,11 +156,15 @@ const productAPI = {
         return { isSuccess: false, message: error.message, code: error.response.status };
       });
   },
-  getCategoryProduct: (productCategory: string): Promise<IResultType<Array<IAllProduct>>> => {
+  getCategoryProduct: (
+    productCategory: string,
+    page: number,
+    size = MAX_SIZE
+  ): Promise<IResultType<Array<IAllProduct>>> => {
     // 카테고리별 조회
     return api
       .get(productAPI.endPoint.getCategoryProduct, {
-        params: { productCategory }
+        params: { productCategory, page, size }
       })
       .then((res: AxiosResponse) => {
         const { data } = res;
@@ -178,12 +183,14 @@ const productAPI = {
   },
   getSearchTitleProduct: (
     productCategory: string,
-    keyword: string
+    keyword: string,
+    page: number,
+    size = MAX_SIZE
   ): Promise<IResultType<Array<IAllProduct>>> => {
     // 제목으로 상품 검색
     return api
       .get(productAPI.endPoint.getSerchTitleProduct, {
-        params: { productCategory, keyword }
+        params: { productCategory, keyword, page, size }
       })
       .then((res: AxiosResponse) => {
         const { data } = res;

--- a/frontend/src/components/CategoryList.vue
+++ b/frontend/src/components/CategoryList.vue
@@ -38,7 +38,7 @@ const props = defineProps({
     required: true
   }
 });
-const emits = defineEmits(['update:selectedCategory']);
+const emits = defineEmits(['change']);
 
 const categoryPageNumber = ref(0);
 const viewCategoryNumber = ref(8);
@@ -47,7 +47,7 @@ const categories = ref(CATEGORY_LIST);
 
 const onChangeCategory = (event: Event) => {
   const target = event.target as HTMLSelectElement;
-  emits('update:selectedCategory', target.value);
+  emits('change', target.value);
 };
 
 const onClickPrevCategory = () => {
@@ -62,7 +62,7 @@ const onClickNextCategory = () => {
 };
 
 const onClickCategory = (category: string) => {
-  emits('update:selectedCategory', category);
+  emits('change', category);
 };
 
 const viewCategory = computed(() => {

--- a/frontend/src/views/user/HomeView.vue
+++ b/frontend/src/views/user/HomeView.vue
@@ -15,7 +15,7 @@
             <span class="material-icons-outlined"> search </span>
           </label>
         </div>
-        <CategoryList v-model:selectedCategory="selectedCategory" />
+        <CategoryList :selectedCategory="selectedCategory" @change="changeCategory" />
       </div>
       <div v-if="products.length" class="card-list">
         <ProductCardVue :products="products" @click="onClickProductCard" />
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watchEffect } from 'vue';
+import { onMounted, ref } from 'vue';
 import router from '@/router';
 import ProductCardVue from '@/components/ProductCard.vue';
 import CommonBannerVue from '@/components/CommonBanner.vue';
@@ -40,20 +40,21 @@ import productAPI from '@/apis/user/product';
 import type { IAllProduct } from '@/types/product';
 import EmptyProduct from '@/components/EmptyProduct.vue';
 import { PLACEHOLDER } from '@/constants/strings/defaultInput';
+import type { IStringToFunction } from '@/types/dynamic';
 
 const selectedCategory = ref('ALL');
-
 const keyword = ref('');
-
 const products = ref<Array<IAllProduct>>([]);
+const pageNumber = ref(0);
+const currentSearch = ref('ALL');
+const isEnd = ref(false);
+const preScroll = ref(0);
 
-const onClickSearch = async () => {
-  const res = await productAPI.getSearchTitleProduct(selectedCategory.value, keyword.value);
-  if (res.isSuccess && res.data) {
-    products.value = res.data;
-  } else {
-    products.value = [];
-  }
+const getProduct: IStringToFunction = {
+  SEARCH: (page: number) =>
+    productAPI.getSearchTitleProduct(selectedCategory.value, keyword.value, page),
+  ALL: (page: number) => productAPI.getAll(page),
+  CATEGORY: (page: number) => productAPI.getCategoryProduct(selectedCategory.value, page)
 };
 
 const onClickAddProduct = () => {
@@ -64,33 +65,69 @@ const onClickProductCard = (id: number) => {
   router.push(`product/${id}`);
 };
 
-watchEffect(async () => {
-  if (selectedCategory.value === 'ALL') {
-    const res = await productAPI.getAll();
-    if (res.isSuccess && res.data) {
-      products.value = res.data;
-    } else {
-      console.error(res.message);
-    }
-
+const handleNotificationListScroll = async () => {
+  const scrollLocation = document.documentElement.scrollTop; // 현재 스크롤바 위치
+  if (Math.abs(preScroll.value - scrollLocation) < 10) {
+    preScroll.value = scrollLocation;
     return;
   }
-
-  const res = await productAPI.getCategoryProduct(selectedCategory.value);
+  preScroll.value = scrollLocation;
+  const windowHeight = window.innerHeight; // 스크린 창
+  const fullHeight = document.body.scrollHeight; //  margin 값은 포함 x
+  if (scrollLocation + windowHeight + 100 > fullHeight) {
+    pageNumber.value += 1;
+    const res = await getProduct[currentSearch.value](pageNumber.value);
+    if (!res.isSuccess) {
+      return;
+    }
+    if (!res.data || res.data.length === 0) {
+      isEnd.value = true;
+      window.removeEventListener('scroll', handleNotificationListScroll);
+      return;
+    }
+    products.value = [...products.value, ...res.data];
+  }
+};
+// 상품 검색
+const onClickSearch = async () => {
+  currentSearch.value = 'SEARCH';
+  pageNumber.value = 0;
+  window.addEventListener('scroll', handleNotificationListScroll);
+  const res = await getProduct[currentSearch.value](pageNumber.value);
   if (res.isSuccess && res.data) {
     products.value = res.data;
   } else {
     products.value = [];
   }
-});
+};
+// 카테고리 변경
+const changeCategory = async (category: string) => {
+  selectedCategory.value = category;
+  pageNumber.value = 0;
+  currentSearch.value = 'CATEGORY';
+  window.addEventListener('scroll', handleNotificationListScroll);
+
+  console.log(selectedCategory.value);
+  if (selectedCategory.value === 'ALL') {
+    currentSearch.value = 'ALL';
+  }
+
+  const res = await getProduct[currentSearch.value](pageNumber.value);
+  if (res.isSuccess && res.data) {
+    products.value = res.data;
+  } else {
+    products.value = [];
+  }
+};
 
 onMounted(async () => {
-  const res = await productAPI.getAll();
+  const res = await getProduct['ALL'](pageNumber.value);
   if (res.isSuccess && res.data) {
     products.value = res.data;
   } else {
     console.error(res.message);
   }
+  window.addEventListener('scroll', handleNotificationListScroll);
 });
 </script>
 

--- a/frontend/src/views/user/HomeView.vue
+++ b/frontend/src/views/user/HomeView.vue
@@ -49,6 +49,7 @@ const pageNumber = ref(0);
 const currentSearch = ref('ALL');
 const isEnd = ref(false);
 const preScroll = ref(0);
+const CARD_SIZE = 400;
 
 const getProduct: IStringToFunction = {
   SEARCH: (page: number) =>
@@ -74,7 +75,7 @@ const handleNotificationListScroll = async () => {
   preScroll.value = scrollLocation;
   const windowHeight = window.innerHeight; // 스크린 창
   const fullHeight = document.body.scrollHeight; //  margin 값은 포함 x
-  if (scrollLocation + windowHeight + 100 > fullHeight) {
+  if (scrollLocation + windowHeight + CARD_SIZE > fullHeight) {
     pageNumber.value += 1;
     const res = await getProduct[currentSearch.value](pageNumber.value);
     if (!res.isSuccess) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 연관된 이슈 번호를 모두 작성해주세요

Close #283 

## ✍🏻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 수정된 api에 맞게 프론트엔드 코드 수정
- 스크롤 위치에 따라 api 호출

1. homeView가 처음 렌더링 될때 모든 상품을 조회하는 API를 호출하고, window 객체에 스크롤이벤트를 추가
2. 만일, 사용자가 검색 혹은 카테고리를 수정했을 경우 currentSearch의 값 변경하면서 pageNumer는 0으로 초기화하며 window 객체에 스크롤 이벤트 추가
   1. 전체조회일 경우 currentSearch = 'ALL'
   2. 검색을 했을 경우 currentSearch = 'SEARCH'
   3. 카테고리를 클릭했을 경우 currentSearch = 'CATEGORY'
3. 스크롤이 특정위치에 도달했을 경우 상품 api를 호출
   1. currentSearch의 상태에 따라 전체, 검색, 카테고리 별로 검색
4. api의 결과값이 빈배열일 경우 더이상 불러올 데이터가 없다고 판단되어 window 객체에 추가한 스크롤 이벤트를 제거

![scroll](https://github.com/woorifisa-projects/GoodFriends/assets/70616579/70fc1b72-faea-4893-a313-40028fe510de)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
