### PR TITLE
Feature/308(주문서를 선택한 경우 주문서 보기 페이지에서 해당 주문서만 확인)

### DIFF
--- a/backend/src/main/java/woorifisa/goodfriends/backend/order/domain/OrderRepository.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/order/domain/OrderRepository.java
@@ -45,4 +45,10 @@ public interface OrderRepository extends JpaRepository<Order,Long> {
             "WHERE o.confirmStatus = :confirmStatus " +
             "AND o.user.id = :userId")
     Long findCountByConfirmStatusAndUserId(ConfirmStatus confirmStatus, Long userId);
+
+    @Query("SELECT o " +
+            "FROM Order o " +
+            "WHERE o.product.id = :productId " +
+            "AND o.confirmStatus = :confirmStatus")
+    Order findByProductIdAndConfirmStatus(Long productId, ConfirmStatus confirmStatus);
 }

--- a/backend/src/main/java/woorifisa/goodfriends/backend/order/dto/response/OrderViewAllResponse.java
+++ b/backend/src/main/java/woorifisa/goodfriends/backend/order/dto/response/OrderViewAllResponse.java
@@ -7,10 +7,13 @@ import java.util.List;
 @Getter
 public class OrderViewAllResponse {
 
-    List<OrderViewOneResponse> responses;
+    private List<OrderViewOneResponse> responses;
 
-    public OrderViewAllResponse(List<OrderViewOneResponse> responses) {
+    private boolean dealStatus;
+
+    public OrderViewAllResponse(List<OrderViewOneResponse> responses, boolean dealStatus) {
         this.responses = responses;
+        this.dealStatus = dealStatus;
     }
 
 }

--- a/frontend/src/apis/user/order.ts
+++ b/frontend/src/apis/user/order.ts
@@ -1,6 +1,6 @@
 import { apiInstance, headers } from '..';
 import type { IResultType, INoContent } from '@/types/api';
-import type { IOrderResponse, IPostOrder, IPurchaser } from '@/types/order';
+import type { IOrder, IOrderResponse, IPostOrder, IPurchaser } from '@/types/order';
 import { type AxiosResponse } from 'axios';
 
 const api = apiInstance();
@@ -12,7 +12,7 @@ const orderAPI = {
     dealOrder: `api/orders/deal/`
   },
   headers: {},
-  getOrder: (token: string, productId: string): Promise<IResultType<Array<IOrderResponse>>> => {
+  getOrder: (token: string, productId: string): Promise<IResultType<IOrder>> => {
     return api
       .get(orderAPI.endPoint.getOrder + productId, {
         headers: {
@@ -22,7 +22,7 @@ const orderAPI = {
       })
       .then((res: AxiosResponse) => {
         console.log(res);
-        return { isSuccess: true, data: res.data.responses, code: res.status };
+        return { isSuccess: true, data: res.data, code: res.status };
       })
       .catch((error) => {
         if (error.response) {
@@ -57,9 +57,9 @@ const orderAPI = {
         return { isSuccess: false, message: error.message, code: error.response.status };
       });
   },
-  dealOrder: (token: string, productId: string): Promise<IResultType<IPurchaser>> => {
+  dealOrder: (token: string, orderId: string): Promise<IResultType<IPurchaser>> => {
     return api
-      .post(orderAPI.endPoint.dealOrder + productId, '', {
+      .post(orderAPI.endPoint.dealOrder + orderId, '', {
         headers: {
           ...headers,
           Authorization: `Bearer ${token}`

--- a/frontend/src/components/ConfirmModal.vue
+++ b/frontend/src/components/ConfirmModal.vue
@@ -6,9 +6,12 @@
           <p v-for="(text, index) in props.content" :key="index">{{ text }}</p>
         </div>
       </div>
-      <div class="modal-buttons" @click="updateResponse">
+      <div v-show="props.visibleButton" class="modal-buttons" @click="updateResponse">
         <button class="no-btn" value="no">no</button>
         <button class="yes-btn" value="yes">yes</button>
+      </div>
+      <div v-show="!props.visibleButton" class="modal-confirm-button " @click="confirmResponse">
+        <button class="confirm-btn" value="confirm">확인</button>
       </div>
     </div>
   </CommonModalVue>
@@ -29,6 +32,10 @@ const props = defineProps({
   content: {
     type: Array<string>,
     default: ['정말 등록하시겠습니까?', '변경내용은 저장되지 않습니다.']
+  },
+  visibleButton: {
+    type: Boolean,
+    default: true
   }
 });
 
@@ -45,6 +52,15 @@ const updateResponse = (event: Event) => {
   }
   emits('update:isVisible', false);
 };
+
+const confirmResponse = (event: Event) => {
+  const target = event.target as HTMLButtonElement;
+  if(target.value === undefined) return;
+  if(target.value === 'confirm') {
+    emits('update:isVisible', true);
+  }
+  emits('update:isVisible', false);
+}
 </script>
 
 <style scoped>
@@ -85,6 +101,26 @@ const updateResponse = (event: Event) => {
 .yes-btn {
   background-color: var(--color-yellow);
 }
+
+.modal-confirm-button {
+  display: flex;
+  justify-content: space-around;
+}
+.confirm-btn:hover {
+  transform: scale(1.03);
+}
+.confirm-btn {
+  font-family: 'LINESeedKR-Bd';
+  font-size: 18px;
+  width: 100px;
+  border: 1px solid rgb(240, 240, 240);
+  border-radius: 12px;
+  padding: 12px 18px;
+
+  transition: transform 0.3s ease;
+  background-color: var(--color-yellow);
+}
+
 @media screen and (max-width: 1200px) {
   /* .modal {
     width: 90vw;

--- a/frontend/src/constants/strings/product.ts
+++ b/frontend/src/constants/strings/product.ts
@@ -14,6 +14,7 @@ export const PRODUCT = {
   ORDER: '주문하기',
   VIEW_ORDER: '주문서 보기',
   DEAL: '거래하기',
+  CONFIRM: '구매자 정보 보기',
   NOTHING: '찾으시는 상품이 없어요 ㅠ.ㅠ',
   SELL_PRODUCT: '해당 조건에 맞는 판매 상품이 없어요',
   PURCHASE_PRODUCT: '해당 조건에 맞는 구매 상품이 없어요'

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -7,6 +7,12 @@ export interface IOrderResponse {
   possibleTime: string;
   requirements: string;
 }
+
+export interface IOrder {
+  responses: Array<IOrderResponse>;
+  dealStatus: boolean;
+}
+
 export interface IPostOrder {
   productId: number;
   possibleDateStart: string;

--- a/frontend/src/views/user/OrderView.vue
+++ b/frontend/src/views/user/OrderView.vue
@@ -6,6 +6,7 @@
       </div>
       <div class="title">{{ product.title }}</div>
     </div>
+    <div v-if="dealStatus" class="deal-status"> 이미 주문서를 선택한 제품입니다.</div>
     <div class="order-list">
       <ul>
         <div class="order-list-header">
@@ -33,13 +34,15 @@
               {{ order.requirements }}
             </div>
             <div class="btn">
-              <button @click="onClickDeal">{{ PRODUCT.DEAL }}</button>
+              <button v-if="dealStatus"  @click="onClickDeal">{{ PRODUCT.CONFIRM }}</button>
+              <button v-else  @click="onClickDeal">{{ PRODUCT.DEAL }}</button>
             </div>
           </div>
         </li>
       </ul>
     </div>
-    <ConfirmModal v-model:is-visible="isVisible" v-model:response="response" :content="contents" />
+    <ConfirmModal v-if="dealStatus" v-model:is-visible="isVisible" v-model:response="response" v-model:visibleButton="showOnlyYes" :content="dealCompleteContents" />
+    <ConfirmModal v-else v-model:is-visible="isVisible" v-model:response="response" :content="contents" />
     <!-- :content="['정말 거래하시겠습니까?', '이후 취소는 불가능합니다.']" -->
   </div>
 </template>
@@ -48,7 +51,7 @@
 import { onMounted, ref, watchEffect } from 'vue';
 import { useRoute } from 'vue-router';
 import image from '@/assets/tmp/images/image.png';
-import { PRODUCT } from '@/constants/strings/product';
+import { ORDER_MODAL, PRODUCT } from '@/constants/strings/product';
 import type { IOrderResponse } from '@/types/order';
 import ConfirmModal from '@/components/ConfirmModal.vue';
 import orderAPI from '@/apis/user/order';
@@ -59,18 +62,22 @@ const route = useRoute();
 
 const isVisible = ref(false);
 const response = ref(false);
+const showOnlyYes = ref(true);
 const id = route.params.id.toString();
 const clickOrderId = ref(0);
 
 const {title, imageUrl} = history.state;
 
 const orderList = ref<Array<IOrderResponse>>();
+const dealStatus = ref(false);
+
 const product = ref({
   image: imageUrl,
   title: title
 });
 
-const contents = ref(['정말 거래하시겠습니까?', '이후 취소는 불가능합니다.']);
+const dealCompleteContents = ref(['','']);
+const contents = ref(ORDER_MODAL.CONFIRM);
 
 const onClickItem = (event: Event, id: number) => {
   const target = event.target as HTMLDivElement;
@@ -78,7 +85,20 @@ const onClickItem = (event: Event, id: number) => {
   clickOrderId.value = id;
 };
 
-const onClickDeal = () => {
+const onClickDeal = async() => {
+  if(dealStatus.value === true) {
+    const res = await orderAPI.dealOrder(
+    localStorage.getItem(LOCAL_STORAGE.ACCESS_TOKEN) || '',
+    clickOrderId.value.toString()
+    );
+    if (res.isSuccess) {
+      isVisible.value = true;
+      response.value = true;
+      showOnlyYes.value = false;
+      dealCompleteContents.value = [`이름: ${res.data?.nickName}`, `이메일: ${res.data?.email}`];
+    }
+  }
+
   isVisible.value = true;
 };
 watchEffect(async () => {
@@ -103,7 +123,8 @@ onMounted(async () => {
     router.go(-1);
   }
   if (res.data) {
-    orderList.value = res.data;
+    orderList.value = res.data.responses;
+    dealStatus.value = res.data.dealStatus;
   }
   console.log(res);
 });
@@ -143,6 +164,13 @@ onMounted(async () => {
   font-family: 'LINESeedKR-Bd';
   font-size: 32px;
 }
+
+.deal-status {
+  font-size: 25px;
+  text-align: center;
+  background-color:  #fbd668;
+}
+
 .order-list {
   margin-top: 24px;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호

> 연관된 이슈 번호를 모두 작성해주세요

Close #308 

## ✍🏻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 주문서를 선택한 상품이면 해당 주문서만 확인 가능하도록 주문서 보기 API 수정
- [x] 주문서 선택한 상품의 주문서 보기 화면에 "이미 주문서를 선택한 제품입니다." 표시
![image](https://github.com/woorifisa-projects/GoodFriends/assets/59864345/968b0b81-8fe4-40eb-91e3-c89df737c5e0)
- [x] 선택된 주문자의 상세 페이지에는 "거래하기" 버튼 대신 "구매자 정보 보기" 버튼 표시
![image](https://github.com/woorifisa-projects/GoodFriends/assets/59864345/691dcbec-d28e-4589-a941-2519df64261b)
- [x] 구매자 정보 표시 모달 버튼 변경
![image](https://github.com/woorifisa-projects/GoodFriends/assets/59864345/3c6fe978-e7f0-4899-9434-32180bbea1ab)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 클래스 혹은 메서드 이름을 XXX로 작성했는데, 혹시 더 이해하기 쉬운 명칭이 있을까요?
